### PR TITLE
Automatically hide controls when not used

### DIFF
--- a/qml/pages/VideoPlayer.qml
+++ b/qml/pages/VideoPlayer.qml
@@ -34,6 +34,14 @@ Page {
     property string author: ""
     property bool _controlsVisible: true
 
+    Timer {
+        id: hideControlsAutomatically
+        interval: 3000
+        running: false
+        repeat: false
+        onTriggered: _controlsVisible = false
+    }
+
     function showHideControls() {
         if (_controlsVisible) {
             showAnimation.start()
@@ -41,10 +49,14 @@ Page {
             hideAnimation.start()
         }
 
-        if ((_controlsVisible && page.orientation === Orientation.Landscape) || page.orientation === Orientation.Portrait)
+        if ((_controlsVisible && page.orientation === Orientation.Landscape) || page.orientation === Orientation.Portrait) {
             showAnimation3.start()
-        else
+        }
+        else {
             hideAnimation3.start()
+        }
+
+        hideControlsAutomatically.restart()
     }
 
     onOrientationChanged: {
@@ -63,7 +75,10 @@ Page {
         app.playing = title
     }
 
-    Component.onCompleted: showHideControls()
+    Component.onCompleted: {
+        showHideControls()
+        hideControlsAutomatically.restart()
+    }
 
     showNavigationIndicator: page.orientation === Orientation.Portrait
 


### PR DESCRIPTION
Automatically hide controls when not used in the VideoPlayer page.
After 3 seconds, the controls will be hidden and shown again when the user taps on the video.