### PR TITLE
"/" is needed or filename gets mangled

### DIFF
--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -35,7 +35,7 @@ Page {
         property bool audioOnlyMode: false
         property bool developerMode: false
         property double buffer: 1.0
-        property string downloadLocation: "/home/nemo/Downloads"
+        property string downloadLocation: "/home/nemo/Downloads/"
     }
 
     SilicaFlickable {


### PR DESCRIPTION
Currently the downloads by default end up in /home/nemo/ and are getting called 'DownloadsName of the Song'